### PR TITLE
Updated repository to show only active webinars in drop list

### DIFF
--- a/Entity/GoToProductRepository.php
+++ b/Entity/GoToProductRepository.php
@@ -2,6 +2,7 @@
 
 namespace MauticPlugin\LeuchtfeuerGoToBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Mautic\CoreBundle\Entity\CommonRepository;
 
 class GoToProductRepository extends CommonRepository
@@ -81,11 +82,13 @@ class GoToProductRepository extends CommonRepository
         }
 
         $qb = $this->createQueryBuilder('e');
+        $expr = $qb->expr();
         $qb
             ->andWhere('e.date BETWEEN :from AND :to')
+            ->andWhere($expr->eq('e.status', ':status'))
             ->setParameter('from', $from)
-            ->setParameter('to', $to)
-        ;
+            ->setParameter('status', 'active', Types::STRING)
+            ->setParameter('to', $to);
 
         return $qb->getQuery()->getResult();
     }


### PR DESCRIPTION
Steps to test,

1. Connect your Mautic with the GoTo Webinar using our [GoTo Plugin](https://github.com/Leuchtfeuer/mautic-goto-bundle)
2. Create a webinar with several sessions
3. Run `leuchtfeuer:goto:sync`
4. Create a Mautic Form with the form field “GoToWebinar - Upcoming Webinars,” choose those from step 2.
5. Cancel one of the sessions in GoTo
6. See the form; the form only lists the **active** webinars