### PR TITLE
Goto Webinar Registration fails with HTTP Code 400 Bad Request if the Organisation Field includes a Pipe Char

### DIFF
--- a/Api/GoToApi.php
+++ b/Api/GoToApi.php
@@ -21,6 +21,16 @@ class GoToApi
         $this->integration = $integration;
     }
 
+    protected function cleanupValues($array) {
+         
+        foreach ($array as $key => $value) {
+                if (strpos($value, '|') !== false) {
+                        $array[$key] = str_replace('|', '', $value);
+                }
+        }
+        return $array;
+    }    
+
     /**
      * @return mixed|string
      *
@@ -46,6 +56,8 @@ class GoToApi
             $operation
         );
 
+        $settings['parameters'] =  $this->cleanupValues($settings['parameters']);
+        
         /** @var Response|array $request */
         $request = $this->integration->makeRequest(
             $url,


### PR DESCRIPTION
The Goto Webinar Registration fails with HTTP Code 400 Bad Request if the Organisation Field includes a Pipe Char. 

See also discussion in: 
https://community.logmein.com/t5/GoToWebinar-Discussions/Pipe-character-in-field-organization-breaks-registrants-REST-API/td-p/253044